### PR TITLE
Add option to allow source files to be placed in the /public dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,33 @@ Given an input file in `app/icons/user.svg`, the contents of that file could be 
   </svg>
 ```
 
+SVGs that are processed by this addon are usually more or less static assets, and it makes sense for them to live in the project's `public/` dir. However, since ember-cli automatically includes all files in `/public` in the build, they effectively get duplicated. To prevent processed files from ending up in `dist/`, use the `excludeSourceFiles` flag:
+
+```js
+// Brocfile.js
+
+var app = new EmberApp({
+  svgstore: {
+    excludeSourceFiles: true, // exclude all processed source files
+    files: {
+      sourceDirs: [ 'public/icons' ],
+      outputFile: '/assets/icons.svg',
+      excludeSourceFiles: true // exclude source files only for this master SVG
+    }
+  }
+});
+```
+
+Note that if your source SVGs are in any other directory (i.e. `/app`, `/vendor`, etc.), they will not automatically be included in the build, and the `excludeSourceFiles` option is not necessary.
+
 ## Options
 
 ### `files`
 May be a single object or an array. Each object should have the following two keys:
  - `sourceDirs` a string or array of strings specifying the directories that should be crawled for SVGs to include
  - `outputFile` the destination to write the final SVG to
+ - `excludeSourceFiles` whether the files in `sourceDirs` are excluded from the build or not
+
+
+### `excludeSourceFiles`
+Boolean indicating whether all source files should be excluded from the build or not, defaults to `false`.

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "homepage": "https://github.com/salsify/ember-cli-svgstore",
   "dependencies": {
+    "broccoli-funnel": "^0.2.3",
     "broccoli-svgstore": "0.1.0",
     "broccoli-unwatched-tree": "^0.1.1",
     "make-array": "^0.1.2",


### PR DESCRIPTION
SVGs that get processed into a spritesheet are more or less static assets, and it makes sense for them to live in the project's `public/` dir. However, by existing in that dir, ember-cli automatically includes them in the distribution, effectively duplicating them all. This adds an option to prevent processed SVGs from making it to the final dist build.