### PR TITLE
update broccoli-svgstore

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   "dependencies": {
     "broccoli-funnel": "^1.0.1",
     "broccoli-merge-trees": "^1.1.1",
-    "broccoli-svgstore": "^0.1.0",
+    "broccoli-svgstore": "^0.2.0",
     "broccoli-unwatched-tree": "^0.1.1",
     "make-array": "^1.0.1",
     "merge": "^1.2.0"


### PR DESCRIPTION
Updated broccoli-svgstore as per https://github.com/svgstore/broccoli-svgstore/pull/8 and https://github.com/svgstore/broccoli-svgstore/pull/12, this should resolve #4.

Verified that tests for this branch pass in latest release, beta, and canary, and I'm running this branch symlinked to an app that makes use of svgstore, so far without issue.