### PR TITLE
update to svgstore 0.4.x and document usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,32 @@ var app = new EmberApp(defaults, {
 
 Note that if your source SVGs are in any other directory (i.e. `/app`, `/vendor`, etc.), they will not automatically be included in the build, and the `excludeSourceFiles` option is not necessary.
 
+Because this addon uses `broccoli-svgstore` and `svgstore` under the hood it's possible
+to pass the `options` accepted by `svgstore` through during the build.
+
+For example, if you wanted to hide your `<svg>` of `<symbols>` from view, but
+still keep it rendered in the DOM, you can take advantage of `svgstore`'s `svgAttrs` option:
+
+```js
+var app = new EmberAddon(defaults, {
+  svgstore: {
+    excludeSourceFiles: true, // exclude all processed source files
+    files: {
+      sourceDirs: [ 'public/icons' ],
+      outputFile: '/assets/icons.svg',
+      excludeSourceFiles: true // exclude source files only for this master SVG
+    },
+    svgstoreOpts: {
+      svgAttrs: {
+        style: 'position: absolute; top: 0; left: 0; width: 0%; height: 0%;'
+      }
+    }
+  }
+});
+```
+
+See the [`svgstore` options API](https://github.com/svgstore/svgstore#options) for more details.
+
 ## Options
 
 ### `files`
@@ -66,3 +92,6 @@ May be a single object or an array. Each object should have the following two ke
 
 ### `excludeSourceFiles`
 Boolean indicating whether all source files should be excluded from the build or not, defaults to `false`.
+
+### `svgstoreOpts`
+An options hash to be passed through to `svgstore`.

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -8,6 +8,11 @@ module.exports = function(defaults) {
       files: {
         sourceDirs: 'tests/dummy/app/icons',
         outputFile: '/assets/test-icons.svg'
+      },
+      svgstoreOpts: {
+        svgAttrs: {
+          style: 'position: absolute; top: 0; left: 0; width: 0%; height: 0%;'
+        }
       }
     }
   });

--- a/index.js
+++ b/index.js
@@ -16,7 +16,8 @@ module.exports = {
   },
 
   treeForPublic: function() {
-    var trees = this._makeSvgTrees(this.options().files);
+    var options = this.options();
+    var trees = this._makeSvgTrees(options.files, options.svgstoreOpts);
     return this._maybeMerge(trees, 'output');
   },
 
@@ -52,9 +53,12 @@ module.exports = {
     return tree;
   },
 
-  _makeSvgTrees: function(files) {
+  _makeSvgTrees: function(files, svgstoreOpts) {
     return makeArray(files).map(function(fileSpec) {
-      return new SVGStore(this._makeSourceTree(fileSpec), { outputFile: fileSpec.outputFile });
+      return new SVGStore(this._makeSourceTree(fileSpec), {
+        outputFile: fileSpec.outputFile,
+        svgstoreOpts: svgstoreOpts
+      });
     }, this);
   },
 

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   "dependencies": {
     "broccoli-funnel": "^1.0.1",
     "broccoli-merge-trees": "^1.1.1",
-    "broccoli-svgstore": "^0.2.0",
+    "broccoli-svgstore": "^0.4.0",
     "broccoli-unwatched-tree": "^0.1.1",
     "make-array": "^1.0.1",
     "merge": "^1.2.0"


### PR DESCRIPTION
Closes #9 

In addition to updating to the latest `broccoli-svgstore`, this change modifies the build to look for an `svgstoreOpts` property on our options hash and passes it through to `broccoli-svgstore` inside of the `_makeSvgTrees` function.

I also documented how this can all be used in the README.