### PR TITLE
Modify options passed to broccoli-merge-trees

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,7 +76,8 @@ module.exports = {
       return trees[0];
     } else {
       return new MergeTrees(trees, {
-        description: 'TreeMerger (SVGStore ' + description + ')'
+        annotation: 'TreeMerger (SVGStore ' + description + ')',
+        overwrite: true
       });
     }
   }


### PR DESCRIPTION
* In order to support this addon being able to be consumed by other addons the option of `overwrite: true` needs to be passed to `broccoli-merge-trees`.

* Per the `broccoli-merge-trees` documentation, the `description` option does not exist and the `annotation` option should be used instead.  This is true for the whole ^1.1.1 semver range of the dependency.